### PR TITLE
chore(012-tsc-watch-mode.solution): add missing "outDir" to complete the solution

### DIFF
--- a/src/010-typescript-in-the-build-process/012-tsc-watch-mode.solution/tsconfig.json
+++ b/src/010-typescript-in-the-build-process/012-tsc-watch-mode.solution/tsconfig.json
@@ -44,7 +44,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist", /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
## Changes Made 🎉

- [x] chore: added "outDir" to tsconfig.json for the 012-tsc-watch-mode solution

### Describe Changes

For the **012-tsc-watch-mode.solution**, I added the `"outDir": "./dist"` setting to `tsconfig.json`. This ensures that all compiled TypeScript files are output to the `./dist` directory, making the output location consistent when running `tsc` or using watch mode.

### Note

I'm really enjoying the Total TypeScript course so far! As I work through the exercises, if I find any small issues or areas for improvement, I'll be happy to leave a PR or create an issue to help out. 

Thanks so much for all your hard work in putting these resources together! 🙌

## Checklist ✅

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
