### PR TITLE
Fix ts-expect error failing for the wrong reason

### DIFF
--- a/src/030-classes/112-public-and-private-properties.solution.2.ts
+++ b/src/030-classes/112-public-and-private-properties.solution.2.ts
@@ -45,7 +45,7 @@ it("Should not be able to access x and y from the outside", () => {
   const canvasNode = new CanvasNode();
 
   // @ts-expect-error
-  canvasNode.x;
+  canvasNode.#x;
   // @ts-expect-error
-  canvasNode.y;
+  canvasNode.#y;
 });


### PR DESCRIPTION
canvasNode.x; is failing because "x" does not exist on CanvasNode, whereas what the example is trying to demonstrate is that it fails in typescript because the property #x is private.

PS: Thanks for making these exercises open source.